### PR TITLE
updated text area height

### DIFF
--- a/sources/scss/override/_form.scss
+++ b/sources/scss/override/_form.scss
@@ -17,7 +17,7 @@ select.form-control:not([size]):not([multiple]),
 }
 
 textarea.form-control {
-  height: 64px !important;
+  height: 64px;
 }
 
 .custom-control {


### PR DESCRIPTION
Hi, text area height should not be `!important` as it is a flexible element.

Thanks for the great theme by the way 👍 