### PR TITLE
Fix color custom properties

### DIFF
--- a/sources/scss/theme/_misc.scss
+++ b/sources/scss/theme/_misc.scss
@@ -2,14 +2,14 @@
 
 :root {
   /* Colors */
-  --primary: color(primary);
-  --secondary: color(fontdark);
-  --success: color(success);
-  --info: color(info);
-  --warning: color(warning);
-  --danger: color(danger);
-  --light: color(light);
-  --dark: color(dark);
+  --primary:  #{color(primary)};
+  --secondary:  #{color(fontdark)};
+  --success:  #{color(success)};
+  --info:  #{color(info)};
+  --warning:  #{color(warning)};
+  --danger:  #{color(danger)};
+  --light:  #{color(light)};
+  --dark:  #{color(dark)};
 }
 
 body, html {


### PR DESCRIPTION
Use interpolation to inject the return of the `color` function into custom properties. Without this, values are passed through to CSS as-is.

CSS before:
```css
:root {
  /* Colors */
  --primary: color(primary);
  --secondary: color(fontdark);
  --success: color(success);
  --info: color(info);
  --warning: color(warning);
  --danger: color(danger);
  --light: color(light);
  --dark: color(dark); }
```

CSS after:
```css
:root {
  /* Colors */
  --primary:  #f1a41e;
  --secondary:  #272829;
  --success:  #30c753;
  --info:  #3abaf4;
  --warning:  #ffc501;
  --danger:  #fc544b;
  --light:  #e3eaef;
  --dark:  #191d21; }
```