### PR TITLE
Fixing references to secondary color in cards and badges

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -725,7 +725,7 @@ select.form-control:not([size]):not([multiple]) {
   .card.card-primary {
     border-top: 2px solid #6777ef; }
   .card.card-secondary {
-    border-top: 2px solid #34395e; }
+    border-top: 2px solid #cdd3d8; }
   .card.card-success {
     border-top: 2px solid #47c363; }
   .card.card-danger {
@@ -1093,7 +1093,7 @@ table tr:hover .table-links {
   .badge.badge-primary {
     background-color: #6777ef; }
   .badge.badge-secondary {
-    background-color: #34395e; }
+    background-color: #cdd3d8; }
   .badge.badge-success {
     background-color: #47c363; }
   .badge.badge-info {

--- a/pages/auth-login-2.html
+++ b/pages/auth-login-2.html
@@ -80,7 +80,7 @@
           <div class="absolute-bottom-left index-2">
             <div class="text-light p-5 pb-2">
               <div class="mb-5 pb-3">
-                <h1 class="mb-2 display-4 font-weight-bold">Good Mornig</h1>
+                <h1 class="mb-2 display-4 font-weight-bold">Good Morning</h1>
                 <h5 class="font-weight-normal text-muted-transparent">Bali, Indonesia</h5>
               </div>
               Photo by <a class="text-light bb" target="_blank" href="https://unsplash.com/photos/a8lTjWJJgLA">Justin Kauffman</a> on <a class="text-light bb" target="_blank" href="https://unsplash.com">Unsplash</a>

--- a/sources/scss/override/_badge.scss
+++ b/sources/scss/override/_badge.scss
@@ -18,7 +18,7 @@
   	background-color: color(primary);
   }
   &.badge-secondary {
-    background-color: color(fontdark);
+    background-color: color(secondary);
   }
   &.badge-success {
     background-color: color(success);

--- a/sources/scss/override/_card.scss
+++ b/sources/scss/override/_card.scss
@@ -150,7 +150,7 @@
     border-top: 2px solid color(primary);
   }
   &.card-secondary {
-    border-top: 2px solid color(fontdark);
+    border-top: 2px solid color(secondary);
   }
   &.card-success {
     border-top: 2px solid color(success);


### PR DESCRIPTION
In secondary class in badges and cards the color reference was to fontdark but it should reference to the secondary color.