### PR TITLE
Remove property on selectgroup-input focus state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # Folders to ignore
 /node_modules/
 /dist/node_modules/
+/pages/layouts/
 
 # OS or Editor folders
 ._*

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 # Folders to ignore
 /node_modules/
 /dist/node_modules/
-/pages/layouts/
 
 # OS or Editor folders
 ._*

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -314,7 +314,6 @@ select.form-control:not([size]):not([multiple]) {
   .selectgroup-button-icon i {
     font-size: 14px; }
 
-.selectgroup-input:focus + .selectgroup-button,
 .selectgroup-input:checked + .selectgroup-button {
   background-color: #6777ef;
   color: #fff;

--- a/sources/scss/override/_form.scss
+++ b/sources/scss/override/_form.scss
@@ -207,7 +207,6 @@ select.form-control:not([size]):not([multiple]) {
 }
 
 .selectgroup-input {
-  &:focus + .selectgroup-button,
   &:checked + .selectgroup-button {
     background-color: color(primary);
     color: #fff;


### PR DESCRIPTION
Remove property selectgroup-input focus state to avoid user confusion when selectgroup-input is uncheck by direct click.