### PR TITLE
Ignore layouts dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # Folders to ignore
 /node_modules/
 /dist/node_modules/
+/pages/layouts/
 
 # OS or Editor folders
 ._*


### PR DESCRIPTION
This folder is unused, it's better to ignore it so we dont have to push it every time we recompile assets