### PR TITLE
fixing datetimepicker on forms-advanced-form.html

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -94,23 +94,23 @@ $(function() {
         if(me.parent().hasClass("active")){
           active = true;
         }
-        
+
         $('.main-sidebar .sidebar-menu li.active > .dropdown-menu').slideUp(500, function() {
-          update_sidebar_nicescroll();          
+          update_sidebar_nicescroll();
           return false;
         });
-        
+
         $('.main-sidebar .sidebar-menu li.active').removeClass('active');
 
         if(active==true) {
-          me.parent().removeClass('active');          
-          me.parent().find('> .dropdown-menu').slideUp(500, function() {            
+          me.parent().removeClass('active');
+          me.parent().find('> .dropdown-menu').slideUp(500, function() {
             update_sidebar_nicescroll();
             return false;
           });
         }else{
-          me.parent().addClass('active');          
-          me.parent().find('> .dropdown-menu').slideDown(500, function() {            
+          me.parent().addClass('active');
+          me.parent().find('> .dropdown-menu').slideDown(500, function() {
             update_sidebar_nicescroll();
             return false;
           });
@@ -120,7 +120,7 @@ $(function() {
       });
 
       $('.main-sidebar .sidebar-menu li.active > .dropdown-menu').slideDown(500, function() {
-        update_sidebar_nicescroll();        
+        update_sidebar_nicescroll();
         return false;
       });
     }
@@ -589,7 +589,7 @@ $(function() {
     }
     if($(".datetimepicker").length) {
       $('.datetimepicker').daterangepicker({
-        locale: {format: 'YYYY-MM-DD hh:mm'},
+        locale: {format: 'YYYY-MM-DD HH:mm'},
         singleDatePicker: true,
         timePicker: true,
         timePicker24Hour: true,


### PR DESCRIPTION
i found some bug on datetimepicker [https://demo.getstisla.com/forms-advanced-form.html](https://demo.getstisla.com/forms-advanced-form.html) when i choose at 13 or above (14,15 ..23). then the clock will show 12 hours ahead. 
example 
i choose 
13 -> 01
14 -> 02
22 -> 10

i fount the problem on assets/js/script.js on line 592
i saw format js using hh:mm not HH:mm
i change and solve problem 

https://stackoverflow.com/questions/34431260/difference-between-hhmm-a-and-hhmm-a/34431334

i fount went i using stisla for learning