### PR TITLE
add select2 options

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -329,7 +329,8 @@ $(function() {
 
   // Select2
   if(jQuery().select2) {
-    $(".select2").select2();
+    const select2Opts = $(".select2").data('select2-opts')
+    $(".select2").select2(select2Opts || {});
   }
 
   // Selectric


### PR DESCRIPTION
select2 options can be set on html `data-select2-opts` attribute.

example:
```html
<select id="tags" name="tags[]" class="form-control select2" multiple
  data-select2-opts='{"tags": "true", "tokenSeparators": [",", " "]}'>
</select>
```