### PR TITLE
ci(docs): build docs on PRs into master

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,36 @@
+name: CI docs
+
+# Build-only check for pull requests into master. Catches a broken docs build
+# BEFORE merge, so the deploy job (deploy-docs.yml, runs on push to master) never
+# fires on a build that was already known to fail. No deploy, no secrets needed.
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/ci-docs.yml"
+
+concurrency:
+  group: ci-docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter docs build


### PR DESCRIPTION
Adds a build-only CI check that runs on PRs into `master` (paths: `docs/**`, `packages/**`, `pnpm-lock.yaml`).

A broken docs build now fails the PR **before** merge, instead of failing the deploy job after it already landed on `master`. No deploy, no secrets.

This PR touches `.github/workflows/ci-docs.yml`, so the check runs on itself — a green check here confirms it works.