### PR TITLE
ci(docs): run build on every PR (safe as required check)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -3,14 +3,13 @@ name: CI docs
 # Build-only check for pull requests into master. Catches a broken docs build
 # BEFORE merge, so the deploy job (deploy-docs.yml, runs on push to master) never
 # fires on a build that was already known to fail. No deploy, no secrets needed.
+#
+# No path filter on purpose: this check is REQUIRED in branch protection, and a
+# required check that gets skipped (path miss) leaves the PR stuck waiting forever.
+# Running on every PR keeps it always-reporting. The build is fast and cached.
 on:
   pull_request:
     branches: [master]
-    paths:
-      - "docs/**"
-      - "packages/**"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/ci-docs.yml"
 
 concurrency:
   group: ci-docs-${{ github.ref }}


### PR DESCRIPTION
Follow-up to #272. That PR merged with a path filter still on the build check. A **required** status check that gets skipped (path miss) leaves a PR stuck 'waiting' forever, so this drops the filter — the docs build now runs on every PR into `master`.

Merge this, then the 'require build to pass' branch protection rule is safe to turn on.