### PR TITLE
chore: first automated release (3.0.1) via OIDC

### DIFF
--- a/.changeset/automated-release-provenance.md
+++ b/.changeset/automated-release-provenance.md
@@ -1,0 +1,9 @@
+---
+"@stisla/css": patch
+"@stisla/style": patch
+"@stisla/vanilla": patch
+---
+
+First release published through automated CI. Publishing now runs via GitHub Actions
+with npm Trusted Publishing (OIDC), so these packages ship with build provenance. No
+runtime, token, class, or API changes.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["@stisla/react", "@stisla/vue"]
+  "ignore": ["@stisla/react", "@stisla/vue", "@stisla-template/meridian-html"]
 }


### PR DESCRIPTION
Smoke-tests the new release pipeline end to end.

- Patch changeset for `@stisla/css`, `@stisla/style`, `@stisla/vanilla` → first release published through CI with npm Trusted Publishing (OIDC) + provenance. No runtime/API changes.
- Config fix surfaced by the test: ignore `@stisla-template/meridian-html` (private, deploys to Cloudflare Pages, not npm) so it isn't versioned as a dependent.

**After this merges:** the Release workflow opens a *Version Packages* PR bumping the three packages to `3.0.1`. Merging **that** PR is what actually publishes to npm and cuts the `@stisla/*@3.0.1` GitHub Releases.