### PR TITLE
chore: drop stale prerelease refs, swap docs domain, add Stisla 3 page

### DIFF
--- a/.changeset/stale-vanilla-version.md
+++ b/.changeset/stale-vanilla-version.md
@@ -1,0 +1,5 @@
+---
+"@stisla/vanilla": patch
+---
+
+Correct the reported `Stisla.version` constant, which was stale (`3.0.0-beta.8`) and now tracks the published package version.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,7 +109,7 @@ reference (Button + Sidebar) stays as-is; don't delete, don't extend.
 These are **unordered** — pick by what's ready / highest-leverage, not top-to-bottom:
 
 - [ ] **Complete `@stisla/css` + `@stisla/vanilla`, then ship.** Land the real dist + npm publish
-      (currently `3.0.0-beta.8`; `dist/` gitignored; publish gated on maintainer). Verify both
+      (currently `3.0.1`; `dist/` gitignored; publish gated on maintainer). Verify both
       bundles (`stisla.css`/`stisla-full.css` + the 3 optional add-ons) and the JS IIFE on a
       no-build page. See [[project_build_pipeline]] / [[project_distribution_model]].
 - [ ] **Complete the illustration page.** Port the full metaphor set + the recolorable-SVG

--- a/docs/src/routes/3.tsx
+++ b/docs/src/routes/3.tsx
@@ -1,0 +1,456 @@
+import { useState, type CSSProperties } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowRight, Check } from "lucide-react";
+import { Code } from "~/demo/Code";
+import { useTheme } from "~/theme";
+
+export const Route = createFileRoute("/3")({
+  component: WhatsNew,
+});
+
+/* Live proof — one token, read everywhere. Clicking a swatch sets the primary
+ * token on the wrapper and every component inside retints at once. We set two
+ * tokens, not one: `--color-primary` is the theme-independent fill, and
+ * `--color-primary-emphasis` is the readable text shade that soft chips and
+ * links wear. Emphasis is the fill shifted in lightness, darker in light mode
+ * and lighter in dark, so we derive it from the same L/C/H per theme rather than
+ * hard-coding a second color. This all also follows the top-bar light/dark
+ * toggle, since the tokens are what the theme swaps. */
+type Swatch = { name: string; l: number; c: number; h: number };
+const SWATCHES: Swatch[] = [
+  { name: "Violet", l: 0.55, c: 0.21, h: 277 },
+  { name: "Blue", l: 0.58, c: 0.17, h: 245 },
+  { name: "Emerald", l: 0.6, c: 0.15, h: 162 },
+  { name: "Amber", l: 0.72, c: 0.16, h: 65 },
+  { name: "Rose", l: 0.62, c: 0.22, h: 12 },
+];
+
+const fill = (s: Swatch) => `oklch(${s.l} ${s.c} ${s.h})`;
+/* Emphasis tracks the fill's chroma and hue, shifting only lightness: darker on
+ * light surfaces, lighter on dark, mirroring how the theme defines it. */
+const emphasis = (s: Swatch, dark: boolean) =>
+  `oklch(${(s.l + (dark ? 0.05 : -0.05)).toFixed(3)} ${s.c} ${s.h})`;
+
+function ThemeDemo() {
+  const { theme } = useTheme();
+  const dark = theme === "dark";
+  const [active, setActive] = useState<Swatch>(SWATCHES[0]);
+
+  return (
+    <div
+      className="not-prose my-8 rounded-2xl border border-border bg-surface p-6 sm:p-8"
+      style={
+        {
+          "--color-primary": fill(active),
+          "--color-primary-emphasis": emphasis(active, dark),
+        } as CSSProperties
+      }
+    >
+      <div className="mb-8 flex flex-wrap items-center gap-2.5">
+        {SWATCHES.map((s) => (
+          <button
+            key={s.name}
+            type="button"
+            onClick={() => setActive(s)}
+            aria-label={s.name}
+            aria-pressed={active.name === s.name}
+            className="grid size-8 place-items-center cursor-pointer rounded-full outline-2 outline-offset-2 outline-transparent transition data-[on=true]:outline-foreground"
+            data-on={active.name === s.name}
+            style={{ background: fill(s) }}
+          >
+            {active.name === s.name && (
+              <Check className="size-4 fill-white" strokeWidth={3} aria-hidden="true" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <button type="button" className="button button--primary">
+            Primary action
+          </button>
+          <button type="button" className="button button--primary button--soft">
+            Soft
+          </button>
+          <span className="badge badge--primary">New</span>
+          <span className="badge badge--soft badge--primary">8 updates</span>
+          <a href="#" className="link">
+            View report
+          </a>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          {[
+            ["Storage", "82%"],
+            ["Bandwidth", "54%"],
+          ].map(([label, w]) => (
+            <div key={label} className="flex items-center gap-3">
+              <span className="w-20 shrink-0 font-mono text-xs text-muted-foreground">
+                {label}
+              </span>
+              <div className="lp-bar flex-1">
+                <span style={{ width: w }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* Live proof — the knob story without the Sass rebuild. Each control writes a
+ * `--button-*` variable straight onto the instance, so the button repaints in
+ * the browser with nothing recompiled. */
+function TuneDemo() {
+  const [radius, setRadius] = useState(12);
+  const [hue, setHue] = useState(257);
+  const [pad, setPad] = useState(28);
+
+  const tone = `oklch(0.64 0.18 ${hue})`;
+  const style = {
+    "--button-radius": `${radius}px`,
+    "--button-padding-inline": `${pad}px`,
+    "--button-tone": tone,
+    "--button-bg": tone,
+    "--button-color": "white",
+  } as CSSProperties;
+
+  const controls: [string, number, number, number, number, (v: number) => void, string][] =
+    [
+      ["radius", radius, 0, 28, 1, setRadius, "px"],
+      ["padding", pad, 12, 48, 2, setPad, "px"],
+      ["hue", hue, 0, 360, 1, setHue, "°"],
+    ];
+
+  return (
+    <div className="not-prose my-8 grid gap-8 rounded-2xl border border-border bg-surface p-6 sm:p-8 lg:grid-cols-2 lg:items-center">
+      <div className="grid min-h-40 place-items-center rounded-xl bg-muted/40 p-8">
+        <button type="button" className="button" style={style}>
+          Deploy changes
+        </button>
+      </div>
+      <div className="flex flex-col gap-5">
+        {controls.map(([label, value, min, max, step, onChange, unit]) => (
+          <label key={label} className="flex items-center gap-4">
+            <span className="w-16 shrink-0 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+              {label}
+            </span>
+            <input
+              type="range"
+              min={min}
+              max={max}
+              step={step}
+              value={value}
+              onChange={(e) => onChange(Number(e.target.value))}
+              className="min-w-0 flex-1"
+              style={{ accentColor: tone } as CSSProperties}
+              aria-label={label}
+            />
+            <span className="w-12 shrink-0 text-right font-mono text-xs tabular-nums text-foreground">
+              {value}
+              {unit}
+            </span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WhatsNew() {
+  return (
+    <main className="max-w-(--shell-max) mx-auto px-6 sm:px-10">
+      <article className="main-container prose dark:prose-invert prose-sm">
+        <h1>Stisla 3</h1>
+        <p className="lead">
+          Stisla started life as a Bootstrap admin theme. Stisla 3 is a full
+          rewrite. We dropped Bootstrap, rebuilt every component from scratch, and
+          put the whole system on Tailwind tokens. Here is what changed, and why
+          we think it was worth it.
+        </p>
+
+        <p>The short version of what is new:</p>
+        <ul>
+          <li>
+            <a href="#bootstrap" className="link">
+              We dropped Bootstrap
+            </a>{" "}
+            and rebuilt every component from scratch.
+          </li>
+          <li>
+            <a href="#tokens" className="link">
+              One set of tokens
+            </a>{" "}
+            that every component reads, so themes change in one place.
+          </li>
+          <li>
+            <a href="#knobs" className="link">
+              Knobs you turn at runtime
+            </a>{" "}
+            instead of Sass you edit and rebuild.
+          </li>
+          <li>
+            <a href="#tailwind" className="link">
+              Built on Tailwind v4
+            </a>
+            , using the layer most projects skip.
+          </li>
+          <li>
+            <a href="#utilities" className="link">
+              Utilities that still win
+            </a>{" "}
+            when you need to override at the call site.
+          </li>
+          <li>
+            <a href="#no-build" className="link">
+              No build step
+            </a>{" "}
+            for the vanilla release.
+          </li>
+          <li>
+            <a href="#meridian" className="link">
+              Meridian
+            </a>
+            , a full dashboard template, and{" "}
+            <a href="#illustrations" className="link">
+              recolorable illustrations
+            </a>
+            .
+          </li>
+        </ul>
+
+        <section id="bootstrap">
+          <h2>We dropped Bootstrap</h2>
+          <p>
+            Stisla started on Bootstrap, and when the rewrite began the plan was
+            to move to the next Bootstrap. So we ported the components onto it to
+            see how it would feel. The thing we kept running into was the variable
+            and color system. Bootstrap spans two worlds at once. Some values live
+            in Sass and resolve at build time, others live in custom properties
+            and resolve in the browser. Following a single color from its Sass
+            source all the way to the variable a component reads is more involved
+            than it looks.
+          </p>
+          <p>
+            By the time the components were done, theming still never came down to
+            turning a single knob, because the two systems stayed mixed. None of
+            this is a knock on Bootstrap. It is a complete design system, and that
+            is the point of it. We just wanted something different, so we rebuilt
+            the foundation.
+          </p>
+          <p>
+            We landed on Tailwind because it already solves the hard part. Tailwind
+            v4 ships a considered scale for color, spacing, and type, a{" "}
+            <code>@theme</code> block where those tokens live as plain custom
+            properties, and a build that resolves everything at once instead of
+            splitting values across Sass and the browser. It gives us one place to
+            put a value and one way to read it, which is exactly what Bootstrap
+            made hard. We build the component layer on top.{" "}
+            <Link to="/docs/why-stisla" className="link">
+              Why Stisla
+            </Link>{" "}
+            covers the reasoning in full.
+          </p>
+        </section>
+
+        <section id="tokens">
+          <h2>One theme, read everywhere</h2>
+          <p>
+            Around thirty semantic tokens name the system&rsquo;s color, type,
+            radius, and spacing. Every component draws from that set and nothing
+            else, so there is one place to change and nothing drifts out of
+            agreement. Change the primary color below and watch every component
+            repaint at once. Flip the theme from the top bar and they follow that
+            too.
+          </p>
+
+          <ThemeDemo />
+
+          <p>
+            The tokens are plain custom properties on the root. That is the whole
+            trick. There is no palette to regenerate and no build to wait on. Set
+            a token and the components that read it update.
+          </p>
+        </section>
+
+        <section id="knobs">
+          <h2>Knobs you turn at runtime</h2>
+          <p>
+            On top of the shared tokens, each component exposes its own variables,
+            like <code>--button-radius</code> and <code>--button-tone</code>, and
+            every one falls back to a token. Set a variable and only that instance
+            changes, while everything else stays on the theme.
+          </p>
+          <p>
+            In the Bootstrap version, reshaping a button meant editing Sass and
+            waiting on a build. Now you set a variable, in the browser. Drag these
+            and the button follows right away.
+          </p>
+
+          <TuneDemo />
+
+          <p>
+            A knob is also a boundary. A component takes only the knobs it was
+            built for, so you can retint a button or round its corners and it stays
+            a button. When you find yourself reaching past what it offers, that is
+            the signal to name a new modifier and define it once.
+          </p>
+        </section>
+
+        <section id="tailwind">
+          <h2>Built on Tailwind</h2>
+          <p>
+            Tailwind v4 is the scale engine underneath Stisla. Spacing, type,
+            color, and the build that tree-shakes what you do not use all come from
+            it. We adopt its <code>@theme</code> for tokens and its{" "}
+            <code>@layer</code> system for everything on top.
+          </p>
+          <p>
+            Tailwind has two layers, <code>@layer components</code> and{" "}
+            <code>@layer utilities</code>, and most projects use only the second.
+            Tailwind&rsquo;s own guidance is to extract a component class when you
+            see repetition, but the extracting is left to you. Stisla commits to
+            the component layer, so your team does not assemble it by hand on every
+            screen.
+          </p>
+          <Code
+            lang="css"
+            code={`
+@layer components {
+  .button {
+    border-radius: var(--button-radius, var(--radius));
+    background: var(--button-bg, var(--button-tone));
+  }
+}
+`}
+          />
+        </section>
+
+        <section id="utilities">
+          <h2>Utilities still win</h2>
+          <p>
+            Committing to components does not take the escape hatch away. Our
+            components sit in <code>@layer components</code> and any utilities you
+            add sit in <code>@layer utilities</code>, which comes later in the
+            cascade. Utilities win by layer precedence, so a one-off override at
+            the call site just works, with no <code>!important</code> and nothing
+            to merge.
+          </p>
+
+          <div className="not-prose my-8 flex flex-wrap items-center gap-4 rounded-2xl border border-border bg-surface p-6 sm:p-8">
+            <button type="button" className="button button--primary">
+              Default button
+            </button>
+            <button
+              type="button"
+              className="button button--primary rounded-none"
+            >
+              With rounded-none
+            </button>
+          </div>
+
+          <Code
+            lang="html"
+            code={`
+<!-- the utility wins over the component's radius, deterministically -->
+<button class="button button--primary rounded-none">Save</button>
+`}
+          />
+        </section>
+
+        <section id="no-build">
+          <h2>No build step</h2>
+          <p>
+            The vanilla release ships precompiled CSS. A component displays with no
+            Tailwind and no Sass present, which is what lets it work in plain HTML,
+            Rails templates, Django pages, and Laravel views. Link the stylesheet
+            and write the markup.
+          </p>
+          <Code
+            lang="html"
+            code={`
+<link rel="stylesheet" href="stisla.css" />
+
+<button class="button button--primary">Save</button>
+`}
+          />
+          <p>
+            Because the tokens are custom properties on the root, you can still
+            retheme this at runtime. Override <code>--color-primary</code> in a
+            style block or from JavaScript and every component repaints, with no
+            recompile.
+          </p>
+        </section>
+
+        <section id="meridian">
+          <h2>A dashboard to start from</h2>
+          <p>
+            Stisla 3 ships with Meridian, a full e-commerce admin template built on
+            the new components. It is seventeen pages of real screens, from orders
+            and products to reports, ready to fork rather than assemble from
+            scratch.
+          </p>
+          <p>
+            <Link to="/templates/$name" params={{ name: "meridian" }} className="link">
+              See the Meridian template
+            </Link>
+            .
+          </p>
+        </section>
+
+        <section id="illustrations">
+          <h2>Recolorable illustrations</h2>
+          <p>
+            Empty states need art, and art usually ignores your theme. Stisla 3
+            ships a set of recolorable empty-state illustrations that read your
+            tokens, so they match your brand color instead of fighting it. Export
+            any of them as SVG or PNG.
+          </p>
+          <p>
+            <Link to="/illustrations" className="link">
+              Browse the illustration gallery
+            </Link>
+            .
+          </p>
+        </section>
+
+        <section id="roadmap">
+          <h2>One spec, many frameworks</h2>
+          <p>
+            Underneath all of this, Stisla is a design specification. Every
+            implementation follows the same contract over the same tokens. The
+            vanilla implementation is complete and stable, and it is what exists
+            today. React on a headless behavior layer is next, with Vue and Svelte
+            on the roadmap.
+          </p>
+        </section>
+
+        <section>
+          <h2>Try it</h2>
+          <p>
+            That is Stisla 3. Install it in a new project, or read the docs to see
+            how the tokens, knobs, and layers fit together.
+          </p>
+          <div className="not-prose mt-6 flex flex-wrap items-center gap-3">
+            <Link
+              to="/docs/vanilla/installation"
+              className="button button--primary button--lg rounded-full"
+            >
+              Get started
+              <ArrowRight aria-hidden="true" />
+            </Link>
+            <Link
+              to="/docs/why-stisla"
+              className="button button--ghost button--neutral button--lg rounded-full"
+            >
+              Read Why Stisla
+              <ArrowRight className="size-4" aria-hidden="true" />
+            </Link>
+          </div>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/docs/src/routes/docs/introduction.tsx
+++ b/docs/src/routes/docs/introduction.tsx
@@ -95,10 +95,10 @@ function IntroductionDocs() {
       <section>
         <h2>Status</h2>
         <p>
-          The current version is 3.0.0-beta.1. The token surface, BEM class
-          names, component APIs, and vanilla JS behavior are stable as of this
-          beta unless a bug forces a change. The React implementation and the
-          full docs site are the remaining work before stable.
+          Stisla 3 is stable. The token surface, BEM class names, component
+          APIs, and vanilla JS behavior are settled and will only change if a
+          bug forces it. The React implementation and the full docs site are the
+          remaining work.
         </p>
         <p>
           v2, the Bootstrap 4 release, is not getting migrated and lives on the{" "}

--- a/docs/src/routes/docs/specification.tsx
+++ b/docs/src/routes/docs/specification.tsx
@@ -1027,8 +1027,7 @@ function SpecificationDocs() {
       <section>
         <h2>Implementations</h2>
         <p>
-          One spec, many implementations. Status as of <code>3.0.0-beta.1</code>
-          .
+          One spec, many implementations. Status as of <code>3.0</code>.
         </p>
         <table>
           <thead>
@@ -1042,7 +1041,7 @@ function SpecificationDocs() {
             <tr>
               <td>Vanilla CSS + JS</td>
               <td>
-                Ships in <code>3.0.0-beta.1</code>
+                Ships in <code>3.0</code>
               </td>
               <td>
                 Reference implementation.{" "}

--- a/docs/src/routes/index.tsx
+++ b/docs/src/routes/index.tsx
@@ -436,12 +436,11 @@ function Home() {
           <div className="grid items-center gap-14 lg:grid-cols-[1fr_1.05fr] lg:gap-20">
             <div>
               <Link
-                to="/templates/$name"
-                params={{ name: "meridian" }}
+                to="/3"
                 className="badge badge--primary badge--soft py-1 pl-1 pr-4"
               >
                 <span className="badge badge--primary mr-1">New</span>
-                Meridian dashbaord template is live!
+                Stisla v3 is released!
               </Link>
               <h1 className="lp-h1 mt-6">
                 Interfaces Built on Constraint,{" "}

--- a/docs/src/styles/layout.css
+++ b/docs/src/styles/layout.css
@@ -59,7 +59,7 @@
 /* === Docs content column === */
 
 .main-container {
-  max-width: 44rem;
+  max-width: 58rem;
   margin-left: auto;
   margin-right: auto;
   padding: 1.5rem 0;

--- a/packages/vanilla/src/index.js
+++ b/packages/vanilla/src/index.js
@@ -66,7 +66,7 @@ if (typeof document !== 'undefined') {
 }
 
 export const Stisla = {
-  version: '3.0.0-beta.8',
+  version: '3.0.2',
   Component,
   Collapsible,
   Accordion,

--- a/templates/README.md
+++ b/templates/README.md
@@ -141,7 +141,7 @@ redirects `/` to the docs templates gallery), then runs
 
 ```
 stisla-templates.pages.dev/
-  index.html                     → redirects to stisla.pages.dev/templates
+  index.html                     → redirects to stisla.dev/templates
   meridian/                      → the template pages + assets
   meridian/meridian.zip          → the download
 ```
@@ -171,7 +171,7 @@ pnpm dlx wrangler pages project create stisla-templates \
 ### Config to know (top of `deploy.mjs`)
 
 - `PROJECT` — the Cloudflare Pages project name (`stisla-templates`).
-- `DOCS_URL` — where `/` redirects (`https://stisla.pages.dev/templates`).
+- `DOCS_URL` — where `/` redirects (`https://stisla.dev/templates`).
 
 ---
 

--- a/templates/deploy.mjs
+++ b/templates/deploy.mjs
@@ -26,7 +26,7 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  * DOCS_URL    where `/` redirects to (your docs templates page). Set the real
  *             docs production origin here. */
 const PROJECT = "stisla-templates";
-const DOCS_URL = "https://stisla.pages.dev/templates";
+const DOCS_URL = "https://stisla.dev/templates";
 
 /* Each template: its build dir, and `mount` = the folder name its markup links
  * to absolutely (Meridian's nav is /meridian/*.html, so it MUST serve at


### PR DESCRIPTION
## What & why

Two related-but-separate commits, per scope discussion.

### 1. Drop stale prerelease refs + point docs at `stisla.dev` (`748920b`)
- **vanilla:** `Stisla.version` constant was hardcoded `3.0.0-beta.8` while the package is published at `3.0.1`. Corrected to `3.0.2` and added a patch changeset so the next release bumps it in step.
- **docs:** `introduction.tsx` and `specification.tsx` still described the current/shipping version as `3.0.0-beta.1`. Reworded to present Stisla 3 as stable (`3.0`).
- **roadmap:** "currently `3.0.0-beta.8`" note updated to `3.0.1`.
- **templates:** the docs-redirect target moved from `stisla.pages.dev/templates` to `stisla.dev/templates` (README + `deploy.mjs` `DOCS_URL`).

No `getstisla.com` references were found anywhere. Historical beta/rc entries in `CHANGELOG.md` / `RELEASE-*.md` were intentionally left as-is (they document real release history). The templates project's own deploy domain `stisla-templates.pages.dev` is unchanged.

### 2. Add Stisla 3 announcement page (`f9a0c55`)
- New `/3` route walking through the rewrite (dropped Bootstrap, one token set, runtime knobs, Tailwind layers, no-build vanilla, Meridian, illustrations) with live theme + tune demos.
- Homepage "New" badge now links to `/3`.
- Widened `main-container` max-width to `58rem` for the announcement layout.

> [!NOTE]
> The homepage badge text reads "Stisla v3 is released!" — that "v3" in user-facing prose runs against the convention to say "Stisla", not "Stisla v3". Flagging in case you want to tweak it before merge.